### PR TITLE
Add missing intensity field to Livox Lidar simulation plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,17 +11,14 @@ A package to provide plug-in for [Livox Series LiDAR](https://www.livoxtech.com)
 ## Branchs
 
 ### main branch
-- enviroment: ROS kinetic + gazebo7
-- pointcloud type: 
+- enviroment: ROS Melodic + Gazebo 9
+- pointcloud type:
   - sensor_msg::pointcloud
-  - sensor_msg::pointcloud2(pcl::Pointcloud\<pcl::PointXYZ\>)
+  - sensor_msg::pointcloud2(pcl::Pointcloud\<pcl::PointXYZI\>)
   - sensor_msg::pointcloud2(pcl::Pointcloud\<pcl::LivoxPointXyzrtl\>)
   - livox_ros_driver::CustomMsg
-  <!-- - livox_ros_driver::CustomMsg -->
 
-### gazebo9
-- enviroment: ROS melodic + gazebo7
-- pointcloud type: sensor_msg::pointcloud2(pcl::Pointcloud\<pcl::PointXYZ\>)
+
 
 ## Dependence
 
@@ -35,7 +32,7 @@ Before you write your urdf file by using this plugin, catkin_make/catkin build i
 
 A simple demo is shown in livox_simulation.launch
 
-Run 
+Run
 ```
     roslauch livox_laser_simulation livox_simulation.launch
 ```
@@ -53,7 +50,7 @@ Change sensor by change the following lines in the robot.xacro into another xacr
 - mid70.csv
 - tele.csv
 
-## Parameters(example by avia)
+## Parameters(example by Avia)
 
 - laser_min_range: 0.1  // min detection range
 - laser_max_range: 200.0  // max detection range
@@ -62,7 +59,7 @@ Change sensor by change the following lines in the robot.xacro into another xacr
 - ros_topic: scan // topic in ros
 - samples: 24000  // number of points in each scan loop
 - downsample: 1 // we can increment this para to decrease the consumption
-- publish_pointcloud_type: 0 // 0 for sensor_msgs::PointCloud, 1 for sensor_msgs::Pointcloud2(PointXYZ), 2 for sensor_msgs::PointCloud2(LivoxPointXyzrtl) 3 for livox_ros_driver::CustomMsg.
+- publish_pointcloud_type: 0 // 0 for sensor_msgs::PointCloud, 1 for sensor_msgs::Pointcloud2(PointXYZI), 2 for sensor_msgs::PointCloud2(LivoxPointXyzrtl) 3 for livox_ros_driver::CustomMsg.
 
 ## Simulation for mapping
 Currently [Fast-LIO](https://github.com/hku-mars/FAST_LIO) is tested when publish_pointcloud_type = 3。

--- a/include/livox_laser_simulation/livox_point_xyzrtl.h
+++ b/include/livox_laser_simulation/livox_point_xyzrtl.h
@@ -1,5 +1,5 @@
 
-  
+
 /*
  * Created on Sun Aug 15 2021
  *
@@ -26,7 +26,7 @@ struct LivoxPointXyzrtl{
 
 }
 
-POINT_CLOUD_REGISTER_POINT_STRUCT (LivoxPointXyzrtl,  
+POINT_CLOUD_REGISTER_POINT_STRUCT (LivoxPointXyzrtl,
                                    (float, x, x)
                                    (float, y, y)
                                    (float, z, z)

--- a/include/livox_laser_simulation/livox_points_plugin.h
+++ b/include/livox_laser_simulation/livox_points_plugin.h
@@ -77,7 +77,7 @@ class LivoxPointsPlugin : public RayPlugin {
  private:
     enum PointCloudType {
         SENSOR_MSG_POINT_CLOUD = 0,
-        SENSOR_MSG_POINT_CLOUD2_POINTXYZ = 1,
+        SENSOR_MSG_POINT_CLOUD2_POINTXYZI = 1,
         SENSOR_MSG_POINT_CLOUD2_LIVOXPOINTXYZRTL = 2,
         LIVOX_ROS_DRIVER_CUSTOM_MSG = 3,
     };
@@ -90,7 +90,7 @@ class LivoxPointsPlugin : public RayPlugin {
     void SendRosTf(const ignition::math::Pose3d& pose, const std::string& father_frame, const std::string& child_frame);
 
     void PublishPointCloud(std::vector<std::pair<int, AviaRotateInfo>>& points_pair);
-    void PublishPointCloud2XYZ(std::vector<std::pair<int, AviaRotateInfo>>& points_pair);
+    void PublishPointCloud2XYZI(std::vector<std::pair<int, AviaRotateInfo>>& points_pair);
     void PublishPointCloud2XYZRTL(std::vector<std::pair<int, AviaRotateInfo>>& points_pair);
     void PublishLivoxROSDriverCustomMsg(std::vector<std::pair<int, AviaRotateInfo>>& points_pair);
 

--- a/src/livox_points_plugin.cpp
+++ b/src/livox_points_plugin.cpp
@@ -94,14 +94,14 @@ void LivoxPointsPlugin::Load(gazebo::sensors::SensorPtr _parent, sdf::ElementPtr
     ROS_INFO_STREAM("downsample:" << downSample);
 
     publishPointCloudType = sdfPtr->Get<uint16_t>("publish_pointcloud_type");
-    ROS_WARN_STREAM("publish_pointcloud_type: " << publishPointCloudType);
+    ROS_INFO_STREAM("publish_pointcloud_type: " << publishPointCloudType);
     ros::init(argc, argv, curr_scan_topic);
     rosNode.reset(new ros::NodeHandle);
     switch (publishPointCloudType) {
         case SENSOR_MSG_POINT_CLOUD:
             rosPointPub = rosNode->advertise<sensor_msgs::PointCloud>(curr_scan_topic, 5);
             break;
-        case SENSOR_MSG_POINT_CLOUD2_POINTXYZ:
+        case SENSOR_MSG_POINT_CLOUD2_POINTXYZI:
         case SENSOR_MSG_POINT_CLOUD2_LIVOXPOINTXYZRTL:
             rosPointPub = rosNode->advertise<sensor_msgs::PointCloud2>(curr_scan_topic, 5);
             break;
@@ -145,8 +145,8 @@ void LivoxPointsPlugin::OnNewLaserScans() {
             case SENSOR_MSG_POINT_CLOUD:
                 PublishPointCloud(points_pair);
                 break;
-            case SENSOR_MSG_POINT_CLOUD2_POINTXYZ:
-                PublishPointCloud2XYZ(points_pair);
+            case SENSOR_MSG_POINT_CLOUD2_POINTXYZI:
+                PublishPointCloud2XYZI(points_pair);
                 break;
             case SENSOR_MSG_POINT_CLOUD2_LIVOXPOINTXYZRTL:
                 PublishPointCloud2XYZRTL(points_pair);
@@ -383,7 +383,7 @@ void LivoxPointsPlugin::PublishPointCloud(std::vector<std::pair<int, AviaRotateI
     }
 }
 
-void LivoxPointsPlugin::PublishPointCloud2XYZ(std::vector<std::pair<int, AviaRotateInfo>> &points_pair) {
+void LivoxPointsPlugin::PublishPointCloud2XYZI(std::vector<std::pair<int, AviaRotateInfo>> &points_pair) {
     auto rayCount = RayCount();
     auto verticalRayCount = VerticalRayCount();
     auto angle_min = AngleMin().Radian();
@@ -396,7 +396,7 @@ void LivoxPointsPlugin::PublishPointCloud2XYZ(std::vector<std::pair<int, AviaRot
 
     sensor_msgs::PointCloud2 scan_point;
 
-    pcl::PointCloud<pcl::PointXYZ> pc;
+    pcl::PointCloud<pcl::PointXYZI> pc;
     pc.points.resize(points_pair.size());
     ros::Time timestamp = ros::Time::now();
     int pt_count = 0;
@@ -409,9 +409,9 @@ void LivoxPointsPlugin::PublishPointCloud2XYZ(std::vector<std::pair<int, AviaRot
             continue;
         }
         if (verticle_index < verticalRayCount && horizon_index < rayCount) {
-            auto index = (verticalRayCount - verticle_index - 1) * rayCount + horizon_index;
-            auto range = rayShape->GetRange(pair.first);
-            auto intensity = rayShape->GetRetro(pair.first);
+            const auto index = (verticalRayCount - verticle_index - 1) * rayCount + horizon_index;
+            const auto range = rayShape->GetRange(pair.first);
+            const auto intensity = rayShape->GetRetro(pair.first);
             if (range >= RangeMax() || range <= RangeMin() || range < 0.1) continue;
 
             scan->set_ranges(index, range);
@@ -420,20 +420,14 @@ void LivoxPointsPlugin::PublishPointCloud2XYZ(std::vector<std::pair<int, AviaRot
             auto rotate_info = pair.second;
             ignition::math::Quaterniond ray;
             ray.Euler(ignition::math::Vector3d(0.0, rotate_info.zenith, rotate_info.azimuth));
-            //                auto axis = rotate * ray * math::Vector3(1.0, 0.0, 0.0);
-            //                auto point = range * axis + world_pose.Pos();//转换成世界坐标系
-
             auto axis = ray * ignition::math::Vector3d(1.0, 0.0, 0.0);
-
-            // if (range < 0.3) {
-            //     ROS_WARN_STREAM("Small pt: range: " << range << ", axis: " << axis);
-            // }
             auto point = range * axis;
-            pcl::PointXYZ pt;
+
+            pcl::PointXYZI pt;
             pt.x = point.X();
             pt.y = point.Y();
             pt.z = point.Z();
-            // if (pt_count < pc.size() && pt_count > 0)
+            pt.intensity = static_cast<float>(intensity);
 #pragma omp critical
             {
                 pc[pt_count] = pt;
@@ -446,7 +440,6 @@ void LivoxPointsPlugin::PublishPointCloud2XYZ(std::vector<std::pair<int, AviaRot
     scan_point.header.stamp = timestamp;
     scan_point.header.frame_id = "livox";
     rosPointPub.publish(scan_point);
-    // SendRosTf(parentEntity->WorldPose(), world->Name(), raySensor->ParentName());
     ros::spinOnce();
     if (scanPub && scanPub->HasConnections() && visualize) {
         scanPub->Publish(laserMsg);
@@ -534,7 +527,7 @@ void LivoxPointsPlugin::PublishLivoxROSDriverCustomMsg(std::vector<std::pair<int
 
     msg.header.frame_id = "livox";
 
-    struct timespec tn; 
+    struct timespec tn;
     clock_gettime(CLOCK_REALTIME, &tn);
 
     msg.timebase = tn.tv_nsec;
@@ -565,15 +558,13 @@ void LivoxPointsPlugin::PublishLivoxROSDriverCustomMsg(std::vector<std::pair<int
 
             auto axis = ray * ignition::math::Vector3d(1.0, 0.0, 0.0);
             auto point = range * axis;
-            // pt.reflectivity = static_cast<float>(intensity);
             livox_ros_driver::CustomPoint pt;
             pt.x = point.X();
             pt.y = point.Y();
             pt.z = point.Z();
-            pt.line = pair.second.line;
-            // ROS_INFO_STREAM("offset_time: " << pt.offset_time );
-            pt.tag = 0x10;
             pt.reflectivity = 100;
+            pt.line = pair.second.line;
+            pt.tag = 0x10;
             msg.points.push_back(pt);
         }
     }


### PR DESCRIPTION
The simulated Livox Lidar was publishing point clouds with the format `sensor_msgs::Pointcloud2(PointXYZ)` instead of `sensor_msgs::Pointcloud2(PointXYZI)`. The difference is the intensity field which is needed to use PassThrough filters (intensity filters).

### Testing

```
roslaunch oxin_gazebo simulation.launch fake_localisation:=true
```

You should see the new intensity field:

```
$ rostopic echo -n 1 /livox/lidar/fields

-
  name: "x"
  offset: 0
  datatype: 7
  count: 1
-
  name: "y"
  offset: 4
  datatype: 7
  count: 1
-
  name: "z"
  offset: 8
  datatype: 7
  count: 1
-
  name: "intensity"
  offset: 16
  datatype: 7
  count: 1
---
```

And in RViz, the point cloud should turn red:

![Screenshot from 2022-04-27 17-55-02](https://user-images.githubusercontent.com/3400230/165631856-352050ad-9035-40b5-be23-37a449bfd3eb.png)


Fixes https://github.com/oxin-ros/oxin_brains/issues/143.

Signed-off-by: Emiliano Borghi <emiliano@smartmachine.nz>